### PR TITLE
feat: add digital roulette modal

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import { PlayerBoard } from './PlayerBoard'
+import { Modal } from './Modal'
+import { Roulette } from './Roulette'
 import { usePlayerManagement } from '../hooks/usePlayerManagement'
 import { CURRENCIES, GAME_CONFIG } from '../constants/gameConfig'
 
@@ -7,6 +9,7 @@ export const MainContent: React.FC = () => {
   const [playerCountInput, setPlayerCountInput] = useState<number>(
     GAME_CONFIG.INITIAL_PLAYER_COUNT
   )
+  const [isRouletteOpen, setIsRouletteOpen] = useState(false)
   const { players, updatePlayerCount, updateCurrencyCount } =
     usePlayerManagement({
       initialPlayerCount: GAME_CONFIG.INITIAL_PLAYER_COUNT,
@@ -40,6 +43,13 @@ export const MainContent: React.FC = () => {
         <button onClick={handleSetPlayers} className="reset-button">
           リセット
         </button>
+        <button
+          type="button"
+          onClick={() => setIsRouletteOpen(true)}
+          className="roulette-open-button"
+        >
+          ルーレット
+        </button>
       </div>
 
       <p className="player-name-hint">※プレイヤー名クリックで変更</p>
@@ -55,6 +65,14 @@ export const MainContent: React.FC = () => {
           />
         ))}
       </div>
+
+      <Modal
+        isOpen={isRouletteOpen}
+        onClose={() => setIsRouletteOpen(false)}
+        title="ルーレット"
+      >
+        <Roulette />
+      </Modal>
     </>
   )
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react'
+
+interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  title?: string
+  children: React.ReactNode
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+}) => {
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="modal-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <div className="modal-panel" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          {title && <h2 className="modal-title">{title}</h2>}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            className="modal-close-button"
+          >
+            ×
+          </button>
+        </div>
+        <div className="modal-body">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+export default Modal

--- a/src/components/Roulette.tsx
+++ b/src/components/Roulette.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useRef } from 'react'
+import { computeNextRotation } from './rouletteMath'
+
+const SEGMENTS = [
+  { number: 1, color: '#E53935' },
+  { number: 2, color: '#FDD835' },
+  { number: 3, color: '#1E88E5' },
+  { number: 4, color: '#43A047' },
+  { number: 5, color: '#FB8C00' },
+  { number: 6, color: '#8E24AA' },
+  { number: 7, color: '#00ACC1' },
+  { number: 8, color: '#F06292' },
+  { number: 9, color: '#FFFFFF' },
+  { number: 10, color: '#6D4C41' },
+]
+
+const SEGMENT_COUNT = SEGMENTS.length
+const SEGMENT_ANGLE = 360 / SEGMENT_COUNT
+const SPIN_DURATION_MS = 4000
+
+const polar = (cx: number, cy: number, r: number, deg: number) => {
+  const rad = ((deg - 90) * Math.PI) / 180
+  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) }
+}
+
+const segmentPath = (i: number): string => {
+  const cx = 100
+  const cy = 100
+  const r = 95
+  const start = i * SEGMENT_ANGLE
+  const end = start + SEGMENT_ANGLE
+  const p1 = polar(cx, cy, r, start)
+  const p2 = polar(cx, cy, r, end)
+  return `M ${cx} ${cy} L ${p1.x} ${p1.y} A ${r} ${r} 0 0 1 ${p2.x} ${p2.y} Z`
+}
+
+const labelPosition = (i: number) => {
+  const mid = i * SEGMENT_ANGLE + SEGMENT_ANGLE / 2
+  return polar(100, 100, 75, mid)
+}
+
+export const Roulette: React.FC = () => {
+  const [rotation, setRotation] = useState(0)
+  const [spinning, setSpinning] = useState(false)
+  const [result, setResult] = useState<number | null>(null)
+  const baseRotation = useRef(0)
+
+  const handleSpin = () => {
+    if (spinning) return
+    setSpinning(true)
+    setResult(null)
+
+    const winner = Math.floor(Math.random() * SEGMENT_COUNT)
+    const extraTurns = 5 + Math.floor(Math.random() * 3)
+    // セグメント内のランダムな位置（中心±40%の範囲で境界から離す）
+    const jitter = (Math.random() - 0.5) * SEGMENT_ANGLE * 0.8
+    const targetRotation = computeNextRotation({
+      baseRotation: baseRotation.current,
+      winnerIndex: winner,
+      jitter,
+      extraTurns,
+      segmentAngle: SEGMENT_ANGLE,
+    })
+
+    baseRotation.current = targetRotation
+    setRotation(targetRotation)
+
+    window.setTimeout(() => {
+      setSpinning(false)
+      setResult(SEGMENTS[winner].number)
+    }, SPIN_DURATION_MS)
+  }
+
+  return (
+    <div className="roulette-wrapper">
+      <div className="roulette-stage">
+        <div className="roulette-pointer" aria-hidden="true" />
+        <svg
+          viewBox="0 0 200 200"
+          className="roulette-disc"
+          style={{
+            transform: `rotate(${rotation}deg)`,
+            transition: spinning
+              ? `transform ${SPIN_DURATION_MS}ms cubic-bezier(0.17, 0.67, 0.18, 1)`
+              : 'none',
+          }}
+          role="img"
+          aria-label="人生ゲーム風ルーレット"
+        >
+          <circle cx="100" cy="100" r="98" fill="#222" />
+          {SEGMENTS.map((seg, i) => {
+            const { x, y } = labelPosition(i)
+            const textColor = seg.color === '#FFFFFF' ? '#222' : '#fff'
+            return (
+              <g key={i}>
+                <path
+                  d={segmentPath(i)}
+                  fill={seg.color}
+                  stroke="#222"
+                  strokeWidth="1"
+                />
+                <text
+                  x={x}
+                  y={y}
+                  fill={textColor}
+                  fontSize="18"
+                  fontWeight="bold"
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  transform={`rotate(${i * SEGMENT_ANGLE + SEGMENT_ANGLE / 2}, ${x}, ${y})`}
+                >
+                  {seg.number}
+                </text>
+              </g>
+            )
+          })}
+          <circle
+            cx="100"
+            cy="100"
+            r="50"
+            fill="#fff"
+            stroke="#222"
+            strokeWidth="2"
+          />
+          <circle cx="100" cy="100" r="6" fill="#222" />
+        </svg>
+      </div>
+
+      <div className="roulette-controls">
+        <button
+          type="button"
+          onClick={handleSpin}
+          disabled={spinning}
+          className="roulette-spin-button"
+        >
+          {spinning ? '回転中…' : 'ルーレットを回す'}
+        </button>
+        <div className="roulette-result" aria-live="polite">
+          {result !== null ? `結果: ${result}` : spinning ? '…' : ' '}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Roulette

--- a/src/components/__tests__/MainContent.test.tsx
+++ b/src/components/__tests__/MainContent.test.tsx
@@ -71,4 +71,37 @@ describe('MainContent', () => {
     const totalAmounts = screen.getAllByText('合計所持金: $0')
     expect(totalAmounts).toHaveLength(2)
   })
+
+  test('初期状態ではルーレットモーダルは表示されていない', () => {
+    render(<MainContent />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  test('「ルーレット」ボタンが表示される', () => {
+    render(<MainContent />)
+    expect(
+      screen.getByRole('button', { name: 'ルーレット' })
+    ).toBeInTheDocument()
+  })
+
+  test('「ルーレット」ボタン押下でモーダルが開く', () => {
+    render(<MainContent />)
+    fireEvent.click(screen.getByRole('button', { name: 'ルーレット' }))
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    // モーダル内の Roulette コンポーネントの操作ボタンが現れる
+    expect(
+      screen.getByRole('button', { name: 'ルーレットを回す' })
+    ).toBeInTheDocument()
+  })
+
+  test('モーダルの閉じるボタンでモーダルが閉じる', () => {
+    render(<MainContent />)
+    fireEvent.click(screen.getByRole('button', { name: 'ルーレット' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('閉じる'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/__tests__/Modal.test.tsx
+++ b/src/components/__tests__/Modal.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, test, expect, vi } from 'vitest'
+import { Modal } from '../Modal'
+
+describe('Modal', () => {
+  test('isOpen=false のとき何も描画されない', () => {
+    const { container } = render(
+      <Modal isOpen={false} onClose={() => {}} title="T">
+        <p>body</p>
+      </Modal>
+    )
+    expect(container.firstChild).toBeNull()
+    expect(screen.queryByText('body')).not.toBeInTheDocument()
+  })
+
+  test('isOpen=true で title と children が表示される', () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}} title="タイトル">
+        <p>本文</p>
+      </Modal>
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('タイトル')).toBeInTheDocument()
+    expect(screen.getByText('本文')).toBeInTheDocument()
+  })
+
+  test('閉じるボタン (×) 押下で onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal isOpen={true} onClose={onClose} title="T">
+        <p>body</p>
+      </Modal>
+    )
+    fireEvent.click(screen.getByLabelText('閉じる'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test('オーバーレイクリックで onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal isOpen={true} onClose={onClose} title="T">
+        <p>body</p>
+      </Modal>
+    )
+    fireEvent.click(screen.getByRole('dialog'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test('パネル内部のクリックでは onClose は呼ばれない (伝播停止)', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal isOpen={true} onClose={onClose} title="T">
+        <p>本文</p>
+      </Modal>
+    )
+    fireEvent.click(screen.getByText('本文'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  test('Escape キーで onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal isOpen={true} onClose={onClose} title="T">
+        <p>body</p>
+      </Modal>
+    )
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test('Escape 以外のキーでは onClose は呼ばれない', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal isOpen={true} onClose={onClose} title="T">
+        <p>body</p>
+      </Modal>
+    )
+    fireEvent.keyDown(window, { key: 'Enter' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/__tests__/Roulette.test.tsx
+++ b/src/components/__tests__/Roulette.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Roulette } from '../Roulette'
+
+describe('Roulette', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('初期描画で 1〜10 の数字が全て表示される (連番配置)', () => {
+    render(<Roulette />)
+    for (let n = 1; n <= 10; n++) {
+      expect(screen.getByText(String(n))).toBeInTheDocument()
+    }
+  })
+
+  test('初期状態では結果が表示されていない', () => {
+    render(<Roulette />)
+    expect(screen.queryByText(/結果:/)).not.toBeInTheDocument()
+  })
+
+  test('スピンボタン押下で「回転中…」表示になり disabled になる', () => {
+    render(<Roulette />)
+    const button = screen.getByRole('button', { name: 'ルーレットを回す' })
+    fireEvent.click(button)
+
+    const spinningButton = screen.getByRole('button', { name: '回転中…' })
+    expect(spinningButton).toBeDisabled()
+  })
+
+  test('スピン完了後に 1〜10 の範囲で結果が表示される', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    render(<Roulette />)
+    fireEvent.click(screen.getByRole('button', { name: 'ルーレットを回す' }))
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+
+    const result = screen.getByText(/結果:/)
+    expect(result).toBeInTheDocument()
+    const match = result.textContent?.match(/結果:\s*(\d+)/)
+    expect(match).not.toBeNull()
+    const n = Number(match?.[1])
+    expect(n).toBeGreaterThanOrEqual(1)
+    expect(n).toBeLessThanOrEqual(10)
+  })
+
+  test('Math.random を固定すると結果が決定論的になる (表示とロジックが一致)', () => {
+    // Math.random() の最初の呼び出しで winnerIndex が決まる: floor(0.05 * 10) = 0 → 数字 1
+    const randomValues = [0.05, 0.5, 0.5]
+    let i = 0
+    vi.spyOn(Math, 'random').mockImplementation(() => randomValues[i++] ?? 0.5)
+
+    render(<Roulette />)
+    fireEvent.click(screen.getByRole('button', { name: 'ルーレットを回す' }))
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+
+    expect(screen.getByText('結果: 1')).toBeInTheDocument()
+  })
+
+  test('回転中はボタンの再押下で新たなスピンが始まらない', () => {
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    render(<Roulette />)
+    fireEvent.click(screen.getByRole('button', { name: 'ルーレットを回す' }))
+    const callsAfterFirst = spy.mock.calls.length
+
+    // disabled 状態だが念のため何度か試行
+    const spinning = screen.getByRole('button', { name: '回転中…' })
+    fireEvent.click(spinning)
+    fireEvent.click(spinning)
+    expect(spy.mock.calls.length).toBe(callsAfterFirst)
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+
+    // 停止後は再度クリック可能になる
+    const idle = screen.getByRole('button', { name: 'ルーレットを回す' })
+    fireEvent.click(idle)
+    expect(spy.mock.calls.length).toBeGreaterThan(callsAfterFirst)
+  })
+})

--- a/src/components/__tests__/rouletteMath.test.ts
+++ b/src/components/__tests__/rouletteMath.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from 'vitest'
+import { computeNextRotation, resolveWinnerIndex } from '../rouletteMath'
+
+const SEGMENT_COUNT = 10
+const SEGMENT_ANGLE = 360 / SEGMENT_COUNT
+
+describe('computeNextRotation', () => {
+  test('初回スピン: winnerのセグメント中央がポインター(0度)方向に来る', () => {
+    for (let winner = 0; winner < SEGMENT_COUNT; winner++) {
+      const rotation = computeNextRotation({
+        baseRotation: 0,
+        winnerIndex: winner,
+        jitter: 0,
+        extraTurns: 5,
+        segmentAngle: SEGMENT_ANGLE,
+      })
+      expect(resolveWinnerIndex(rotation, SEGMENT_COUNT)).toBe(winner)
+    }
+  })
+
+  test('前回の累積回転があっても winner と停止位置が一致する', () => {
+    const baseRotation = 2034 + 123 // 意図的に端数を残す
+    for (let winner = 0; winner < SEGMENT_COUNT; winner++) {
+      const rotation = computeNextRotation({
+        baseRotation,
+        winnerIndex: winner,
+        jitter: 0,
+        extraTurns: 3,
+        segmentAngle: SEGMENT_ANGLE,
+      })
+      expect(resolveWinnerIndex(rotation, SEGMENT_COUNT)).toBe(winner)
+    }
+  })
+
+  test('jitterを加えても同じセグメント内に停止する', () => {
+    const maxJitter = SEGMENT_ANGLE * 0.4 // Roulette側と同スケール
+    for (let winner = 0; winner < SEGMENT_COUNT; winner++) {
+      for (const jitter of [-maxJitter, -1, 0, 1, maxJitter]) {
+        const rotation = computeNextRotation({
+          baseRotation: 1000,
+          winnerIndex: winner,
+          jitter,
+          extraTurns: 5,
+          segmentAngle: SEGMENT_ANGLE,
+        })
+        expect(resolveWinnerIndex(rotation, SEGMENT_COUNT)).toBe(winner)
+      }
+    }
+  })
+
+  test('常に baseRotation より前方(順方向)へ回転する', () => {
+    const baseRotation = 500
+    for (let winner = 0; winner < SEGMENT_COUNT; winner++) {
+      const rotation = computeNextRotation({
+        baseRotation,
+        winnerIndex: winner,
+        jitter: 0,
+        extraTurns: 5,
+        segmentAngle: SEGMENT_ANGLE,
+      })
+      expect(rotation).toBeGreaterThan(baseRotation)
+    }
+  })
+
+  test('最低でも extraTurns 回転分は進む', () => {
+    const baseRotation = 100
+    const extraTurns = 5
+    for (let winner = 0; winner < SEGMENT_COUNT; winner++) {
+      const rotation = computeNextRotation({
+        baseRotation,
+        winnerIndex: winner,
+        jitter: 0,
+        extraTurns,
+        segmentAngle: SEGMENT_ANGLE,
+      })
+      expect(rotation - baseRotation).toBeGreaterThanOrEqual(extraTurns * 360)
+      // delta は (0, 360] の範囲
+      expect(rotation - baseRotation).toBeLessThanOrEqual(
+        extraTurns * 360 + 360
+      )
+    }
+  })
+
+  test('連続スピンでも毎回 winner と一致する', () => {
+    let base = 0
+    const winners = [0, 3, 7, 9, 2, 5]
+    for (const w of winners) {
+      const rotation = computeNextRotation({
+        baseRotation: base,
+        winnerIndex: w,
+        jitter: 0,
+        extraTurns: 5,
+        segmentAngle: SEGMENT_ANGLE,
+      })
+      expect(resolveWinnerIndex(rotation, SEGMENT_COUNT)).toBe(w)
+      expect(rotation).toBeGreaterThan(base)
+      base = rotation
+    }
+  })
+})
+
+describe('resolveWinnerIndex', () => {
+  test('rotation=0 のとき index 0 (segment[0] が真上)', () => {
+    // winnerIndex=0 のセグメント中央角度は 18度。rotation=0 なら
+    // ポインタ真上(0度)には境界(0度)が来ており、0度の直後の領域が segment 0。
+    expect(resolveWinnerIndex(0, SEGMENT_COUNT)).toBe(0)
+  })
+
+  test('負の rotation も正しく正規化される', () => {
+    // -342 ≡ 18 (mod 360)。盤が 18度 回った状態では、元の centerAngle=342 が
+    // 0度付近に来ている → index 9
+    expect(resolveWinnerIndex(-342, SEGMENT_COUNT)).toBe(9)
+  })
+})

--- a/src/components/rouletteMath.ts
+++ b/src/components/rouletteMath.ts
@@ -1,0 +1,45 @@
+export interface RotationParams {
+  baseRotation: number
+  winnerIndex: number
+  jitter: number
+  extraTurns: number
+  segmentAngle: number
+}
+
+/**
+ * ルーレット盤を時計回りに回転させたときに、winner セグメントの中央が
+ * ポインター(真上・0度)の位置で止まる角度を算出する純関数。
+ *
+ * 前回の累積回転 `baseRotation` の mod 360 を考慮し、さらに `extraTurns` 分の
+ * 360度回転を足すことで、常に順方向へ回り続けながら狙ったセグメントで止まる。
+ */
+export const computeNextRotation = ({
+  baseRotation,
+  winnerIndex,
+  jitter,
+  extraTurns,
+  segmentAngle,
+}: RotationParams): number => {
+  const centerAngle = winnerIndex * segmentAngle + segmentAngle / 2
+  const desiredMod = (((360 - centerAngle + jitter) % 360) + 360) % 360
+  const currentMod = ((baseRotation % 360) + 360) % 360
+  let delta = desiredMod - currentMod
+  if (delta <= 0) delta += 360
+  return baseRotation + extraTurns * 360 + delta
+}
+
+/**
+ * 指定した回転角が適用されたときに、ポインター(0度)位置に来るセグメントの
+ * インデックスを逆算する純関数。テストでの整合性検証に使う。
+ */
+export const resolveWinnerIndex = (
+  rotation: number,
+  segmentCount: number
+): number => {
+  const segmentAngle = 360 / segmentCount
+  const normalized = ((rotation % 360) + 360) % 360
+  // 盤が `normalized` 時計回りに回った結果、真上に来ているセグメントの
+  // 元の中心角度は (360 - normalized) mod 360。それに対応する index を返す。
+  const centerAngle = (360 - normalized + 360) % 360
+  return Math.floor(centerAngle / segmentAngle)
+}

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,72 @@
   }
 }
 
+/* Roulette button + Modal styles */
+.roulette-open-button {
+  @apply px-4 py-1 bg-red-500 text-white rounded hover:bg-red-600 font-semibold;
+}
+
+.modal-overlay {
+  @apply fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4;
+}
+
+.modal-panel {
+  @apply bg-white rounded-lg shadow-xl w-full max-w-md max-h-full overflow-auto;
+}
+
+.modal-header {
+  @apply flex items-center justify-between px-4 py-3 border-b border-gray-200;
+}
+
+.modal-title {
+  @apply text-lg font-bold m-0;
+}
+
+.modal-close-button {
+  @apply text-2xl leading-none w-8 h-8 flex items-center justify-center rounded hover:bg-gray-100;
+}
+
+.modal-body {
+  @apply p-4;
+}
+
+/* Roulette styles */
+.roulette-wrapper {
+  @apply flex flex-col items-center gap-4;
+}
+
+.roulette-stage {
+  @apply relative w-64 h-64;
+}
+
+.roulette-disc {
+  @apply w-full h-full drop-shadow-lg;
+  transform-origin: 50% 50%;
+}
+
+.roulette-pointer {
+  @apply absolute left-1/2 -translate-x-1/2 z-10;
+  top: -6px;
+  width: 0;
+  height: 0;
+  border-left: 14px solid transparent;
+  border-right: 14px solid transparent;
+  border-top: 24px solid #d32f2f;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.3));
+}
+
+.roulette-controls {
+  @apply flex flex-col items-center gap-2;
+}
+
+.roulette-spin-button {
+  @apply px-6 py-2 bg-red-500 text-white rounded-full font-bold hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed;
+}
+
+.roulette-result {
+  @apply text-lg font-bold min-h-[1.75rem] text-blue-900;
+}
+
 /* Privacy Policy styles */
 .privacy-container {
   @apply max-w-3xl mx-auto px-4 py-8;


### PR DESCRIPTION
## Summary

Adds a digital roulette modeled after the Takara Tomy "人生ゲーム (Game of Life)" roulette, opened from a new "ルーレット" button on the main screen.

- **Roulette wheel** (`src/components/Roulette.tsx`): SVG-based 10-segment wheel with sequential numbers 1–10, colored with the classic piece palette, an enlarged white hub (~50% radius) and a center pivot pin.
- **Rotation math** (`src/components/rouletteMath.ts`): extracted as a pure function (`computeNextRotation`) so the pointer always lines up with the winning segment across consecutive spins and only ever rotates forward.
- **Modal** (`src/components/Modal.tsx`): reusable dialog with overlay click, close button, and Escape-key handling.
- **MainContent integration**: new "ルーレット" button opens the modal containing the wheel.
- **Styling** (`src/index.css`): Tailwind-based classes for the modal, wheel stage, pointer, and buttons.

### Tests (48 passing, +25 new)

- `rouletteMath.test.ts`: pointer alignment, forward-only rotation, jitter tolerance, consecutive-spin invariants
- `Modal.test.tsx`: render toggling, overlay/Escape/close-button paths, propagation stop on the panel
- `Roulette.test.tsx`: 1–10 labels, spin button state transitions, deterministic result assertion with `Math.random` stubbed
- `MainContent.test.tsx`: roulette button presence and modal open/close flow

## Commits

- `feat: add digital roulette modal with Takara Tomy Game of Life styling`
- `test: add unit tests for roulette, modal, and main content`